### PR TITLE
Relax timestamp checking

### DIFF
--- a/hearvalidator/validate.py
+++ b/hearvalidator/validate.py
@@ -262,15 +262,7 @@ class ValidateModel:
                     f"Your timestamps begin at {min_time}ms, which appears to be "
                     "wrong."
                 )
-            if max_time < 1000 * length - 2 * avg_diff:
-                raise ModelError(
-                    f"Your timestamps end at {max_time}ms, but the "
-                    f"audio is {1000 * length} ms. You won't have "
-                    f"embeddings for events at the end of the audio."
-                )
-            elif (max_time < 1000 * length - avg_diff) or (
-                max_time < 1000 * length - 50
-            ):
+            if (max_time < 1000 * length - avg_diff) or (max_time < 1000 * length - 50):
                 warnings.warn(
                     f"Your timestamps end at {max_time}ms, but the "
                     f"audio is {1000 * length} ms. You won't have "

--- a/hearvalidator/validate.py
+++ b/hearvalidator/validate.py
@@ -262,13 +262,15 @@ class ValidateModel:
                     f"Your timestamps begin at {min_time}ms, which appears to be "
                     "wrong."
                 )
-            if max_time < 1000 * length - avg_diff:
+            if max_time < 1000 * length - 2 * avg_diff:
                 raise ModelError(
                     f"Your timestamps end at {max_time}ms, but the "
                     f"audio is {1000 * length} ms. You won't have "
                     f"embeddings for events at the end of the audio."
                 )
-            if max_time < 1000 * length - 50:
+            elif (max_time < 1000 * length - avg_diff) or (
+                max_time < 1000 * length - 50
+            ):
                 warnings.warn(
                     f"Your timestamps end at {max_time}ms, but the "
                     f"audio is {1000 * length} ms. You won't have "


### PR DESCRIPTION
There's a weird issue that wav2vec2 which is 16KHz and 20ms hop length, will take 31680 sample audio and give 98 timestamps. That only works if it starts at 20ms